### PR TITLE
Allow cross origin resource sharing 

### DIFF
--- a/api/parentsearch.go
+++ b/api/parentsearch.go
@@ -63,6 +63,7 @@ func (api *SearchAPI) postParentSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setJSONContentType(w)
+	setAccessControl(w)
 	_, err = w.Write(b)
 	if err != nil {
 		log.Event(ctx, "postParentSearch: error writing response", log.ERROR, log.Error(err), logData)

--- a/api/parentsearch.go
+++ b/api/parentsearch.go
@@ -173,6 +173,7 @@ func (api *SearchAPI) getParentSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setJSONContentType(w)
+	setAccessControl(w)
 	_, err = w.Write(b)
 	if err != nil {
 		log.Event(ctx, "error writing response", log.ERROR, log.Error(err), logData)

--- a/api/postcodesearch.go
+++ b/api/postcodesearch.go
@@ -168,6 +168,7 @@ func (api *SearchAPI) getPostcodeSearch(w http.ResponseWriter, r *http.Request) 
 	}
 
 	setJSONContentType(w)
+	setAccessControl(w)
 	_, err = w.Write(b)
 	if err != nil {
 		log.Event(ctx, "error writing response", log.ERROR, log.Error(err), logData)
@@ -179,6 +180,9 @@ func (api *SearchAPI) getPostcodeSearch(w http.ResponseWriter, r *http.Request) 
 
 func setJSONContentType(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "application/json")
+}
+func setAccessControl(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 }
 
 func setErrorCode(w http.ResponseWriter, err error) {


### PR DESCRIPTION
### What

Browsers block resource requests to any domain or port that the frontend isn't running on. If making external requests then preflight requests are sent to check access control, if the access-control-allow-origin header is not found then it blocks the request if the header is found it checks if it is allowed to process the response if yes then it will send the request. 

This PR adds the access-control-allow-origin header and sets all locations to be allowed. Note If prefered I can lock this down further but figured data vis may endup using this so have left it open to all.

Also note that we can make it so this header is only added if it is a cross origin resource share by checking it the request has the origin header (browsers will add this but REST clients won't necessarily set it) - as it is an alpha and a POC I haven't bothered but if preferred can add.

### How to review

Make sure the correct header has been set and we are happy with the value

### Who can review

Anyone except me
